### PR TITLE
Check for _test.go files outside package too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOPATH   = $(CURDIR)/.gopath~
 BIN      = $(GOPATH)/bin
 BASE     = $(GOPATH)/src/$(PACKAGE)
 PKGS     = $(or $(PKG),$(shell cd $(BASE) && env GOPATH=$(GOPATH) $(GO) list ./... | grep -v "^$(PACKAGE)/vendor/"))
-TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if .TestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS))
+TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS))
 
 GO      = go
 GODOC   = godoc


### PR DESCRIPTION
Currently, it will only add package `foo` if its `_test.go` files belong to `foo` package but not package `bar` if its `_test.go` files belong to `bar_test` package.

This PR introduces the ability to add packages with `_test.go` files *outside* package to `TESTPKGS`.