### PR TITLE
explicitely pass gopath to godep ensure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 # Dependency management
 
 vendor: Gopkg.toml Gopkg.lock | $(BASE) $(GODEP) ; $(info $(M) retrieving dependencies…)
-	$Q cd $(BASE) && $(GODEP) ensure
+	$Q cd $(BASE) && GOPATH=$(GOPATH) $(GODEP) ensure
 	@ln -nsf . vendor/src
 	@touch $@
 .PHONY: vendor-update


### PR DESCRIPTION
without this I was getting:
both /home/XXXX/Desktop/git/atch/.gopath~/src/atch and /home/XXXX/Desktop/git/atch are not within any known GOPATH
make: *** [vendor] Error 1