### PR TITLE
Explicit GOPATH export for older make support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ BASE     = $(GOPATH)/src/$(PACKAGE)
 PKGS     = $(or $(PKG),$(shell cd $(BASE) && env GOPATH=$(GOPATH) $(GO) list ./... | grep -v "^$(PACKAGE)/vendor/"))
 TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS))
 
+export GOPATH
+
 GO      = go
 GODOC   = godoc
 GOFMT   = gofmt


### PR DESCRIPTION
This fixes an issue on `make` version `GNU Make 3.81` where `GOPATH` was not passed to childs