### PR TITLE
Fix golint download URL causing broken builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(BIN)/%: | $(BIN) ; $(info $(M) building $(REPOSITORY)…)
 	   rm -rf $$tmp ; exit $$ret
 
 GOLINT = $(BIN)/golint
-$(BIN)/golint: REPOSITORY=github.com/golang/lint/golint
+$(BIN)/golint: REPOSITORY=golang.org/x/lint/golint
 
 GOCOVMERGE = $(BIN)/gocovmerge
 $(BIN)/gocovmerge: REPOSITORY=github.com/wadey/gocovmerge


### PR DESCRIPTION
This change made in golint: https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58 caused errors when trying to run the Makefile if golint didn't already exist. In the README of goling they say you should install it from toe golang.org URL, rather then the GitHub url.